### PR TITLE
Updated links on documentation

### DIFF
--- a/docs/providers/thirdparty.md
+++ b/docs/providers/thirdparty.md
@@ -9,7 +9,7 @@ Third-Party Providers
 
 These providers allow integration with other providers not supported by `oauth2-client`. They may require an older
 version so please help them out with a pull request if you notice this. If you're looking for an official `league` provider,
-you can check out the [first party providers](/providers/league) page.
+you can check out the [first party providers](/providers/league.md) page.
 
 Since all of these packages depend on `league/oauth2-client` as their base, installation is as simple as requiring the
 package you wish to use via composer:

--- a/docs/providers/thirdparty.md
+++ b/docs/providers/thirdparty.md
@@ -9,7 +9,7 @@ Third-Party Providers
 
 These providers allow integration with other providers not supported by `oauth2-client`. They may require an older
 version so please help them out with a pull request if you notice this. If you're looking for an official `league` provider,
-you can check out the [first party providers](docs/providers/league) page.
+you can check out the [first party providers](league) page.
 
 Since all of these packages depend on `league/oauth2-client` as their base, installation is as simple as requiring the
 package you wish to use via composer:

--- a/docs/providers/thirdparty.md
+++ b/docs/providers/thirdparty.md
@@ -9,7 +9,7 @@ Third-Party Providers
 
 These providers allow integration with other providers not supported by `oauth2-client`. They may require an older
 version so please help them out with a pull request if you notice this. If you're looking for an official `league` provider,
-you can check out the [first party providers](/docs/providers/league) page.
+you can check out the [first party providers](docs/providers/league) page.
 
 Since all of these packages depend on `league/oauth2-client` as their base, installation is as simple as requiring the
 package you wish to use via composer:

--- a/docs/providers/thirdparty.md
+++ b/docs/providers/thirdparty.md
@@ -9,7 +9,7 @@ Third-Party Providers
 
 These providers allow integration with other providers not supported by `oauth2-client`. They may require an older
 version so please help them out with a pull request if you notice this. If you're looking for an official `league` provider,
-you can check out the [first party providers](/providers/league.md) page.
+you can check out the [first party providers](/docs/providers/league) page.
 
 Since all of these packages depend on `league/oauth2-client` as their base, installation is as simple as requiring the
 package you wish to use via composer:

--- a/docs/providers/thirdparty.md
+++ b/docs/providers/thirdparty.md
@@ -9,7 +9,7 @@ Third-Party Providers
 
 These providers allow integration with other providers not supported by `oauth2-client`. They may require an older
 version so please help them out with a pull request if you notice this. If you're looking for an official `league` provider,
-you can check out the [first party providers](league) page.
+you can check out the [first party providers](league.md) page.
 
 Since all of these packages depend on `league/oauth2-client` as their base, installation is as simple as requiring the
 package you wish to use via composer:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -7,7 +7,7 @@ title: "Basic Usage"
 Basic Usage
 =============
 
-> Note: In most cases, you'll be much better served by using a specific [official](/providers/league) or [third-party](/providers/thirdparty)
+> Note: In most cases, you'll be much better served by using a specific [official](/providers/league.md) or [third-party](/providers/thirdparty.md)
 provider client library rather than this base library alone.
 
 Authorization Code Flow

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -7,7 +7,7 @@ title: "Basic Usage"
 Basic Usage
 =============
 
-> Note: In most cases, you'll be much better served by using a specific [official](/providers/league.md) or [third-party](/providers/thirdparty.md)
+> Note: In most cases, you'll be much better served by using a specific [official](/docs/providers/league.md) or [third-party](/docs/providers/thirdparty.md)
 provider client library rather than this base library alone.
 
 Authorization Code Flow


### PR DESCRIPTION
As a user, I was experiencing 404 links when I clicked on these links in the usage.md and thirdparty.md.  Am fixing the link here, which now works on the github page view.